### PR TITLE
OS X 10.11 update

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,17 @@
-Toggle Function Keys for OS X (10.6)
+Toggle Function Keys for OS X (10.11)
 ==============
 
-This is a modified version of an AppleScript from [Macsteps](http://macsteps.com/blog/tips/how-to-quickly-toggle-your-keyboards-function-keys/), updated to support OS X 10.6 and to put up a Growl notification with the new status. There's also a Download available bundled as a shiny application, so no fancy script menu nonsense is necessary - just run the app.
+This is a modified version of an AppleScript from [Macsteps](http://macsteps.com/blog/tips/how-to-quickly-toggle-your-keyboards-function-keys/),
+updated to support OS X 10.11 and to put up a system notification so you know
+what state the keys are in.
 
-This will only work in English at the moment due to its reliance on GUI scripting.
+A signed app-ified version of this script is coming soon; in the meantime, to
+get an easily-run binary, open the script file and choose "File -> Export" with
+File Format of "App."
+
+Note that this will only work in English at the moment due to its reliance on
+GUI scripting.
+
+This (in theory) should work on any OS X 10.8+ English Mac - I've only tested
+the latest version against OS X 10.11, though, so feel free to fork/PR if you
+run into any issues on other versions of OS X.

--- a/Toggle Function Keys.applescript
+++ b/Toggle Function Keys.applescript
@@ -17,28 +17,15 @@ tell application "System Events"
 				set messageToShow to messageToShow & "media/hardware controls."
 			end if
 			
-			tell application "GrowlHelperApp"
-				-- Make a list of all the notification types 
-				-- that this script will ever send:
-				set the allNotificationsList to {"Function Keys Toggled"}
-				-- Make a list of the notifications 
-				-- that will be enabled by default.      
-				-- Those not enabled by default can be enabled later 
-				-- in the 'Applications' tab of the growl prefpane.
-				set the enabledNotificationsList to {"Function Keys Toggled"}
-				-- Register our script with growl.
-				register as application "Toggle Function Keys" all notifications allNotificationsList default notifications enabledNotificationsList icon of application "Script Editor"
-				-- Send a Notification...
-				notify with name "Function Keys Toggled" title "Function Keys Toggled" description messageToShow application name "Toggle Function Keys"
-			end tell
+			display notification messageToShow
 		end tell
 		tell application "System Preferences" to quit
 	else
 		-- GUI scripting not enabled.  Display an alert
 		tell application "System Preferences"
 			activate
-			set current pane to pane "com.apple.preference.universalaccess"
-			display dialog "UI element scripting is not enabled. Please activate \"Enable access for assistive devices\""
+			set current pane to pane "com.apple.preference.security"
+			display dialog "UI element scripting is not enabled. Please activate this app under Privacy -> Accessibility so it can access the settings it needs."
 		end tell
 	end if
 end tell


### PR DESCRIPTION
* Toggle Function Keys for Snow-Yosemite.
* Disabled scripting brings you to the new home
  for the UI element scripting toggle, under
  Security.
* Use system notifications instead of Growl, 
  getting us up to date with 2012's hot new OS X
  features.